### PR TITLE
Update Raspberry Pi VID

### DIFF
--- a/src/jtag/drivers/tamarin.c
+++ b/src/jtag/drivers/tamarin.c
@@ -77,7 +77,7 @@ struct tamarin_cmd_hdr_enc {
 #define TAMARIN_QUEUE_SIZE 64
 
 
-#define VID 0x2E8A /* Raspberry Pi */
+#define VID 0x2B3E /* Raspberry Pi */
 #define PID 0x0004 /* Picoprobe */
 
 #define BULK_EP_OUT 4


### PR DESCRIPTION
When running OpenOCD, it can't find the Raspberry Pi Pico. 
```
$ sudo ./src/openocd -f tcl/interface/tamarin.cfg -f t8010.cfg 
Open On-Chip Debugger 0.10.0+dev-g88a95648 (2022-08-27-17:07)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'swd'
Warn : Transport "swd" was already selected
adapter speed: 5000 kHz

Warn : Interface already configured, ignoring
Warn : Transport "swd" was already selected
Error: Failed to open or find the device
Error: Can't find a tamarin device! Please check device connections and permissions
```

By looking at the `lsusb` ouput, it seem the Vendor ID is wrong in `src/jtag/drivers/tamarin.c`:
```
λ ~ » lsusb | grep Tamarin
Bus 001 Device 005: ID 2b3e:0004 NewAE Technology Inc. Tamarin Cable
```

This PR changes the VID to the actual RPI Pico VID.